### PR TITLE
Use a message queue to deliver responses to clients.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 revision.txt
 env
 build/
+dump.rdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
 install:
   - pip install -U tox
 
-services:
-  - mongodb
-
 script:
   - tox
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==0.10.1
 git+https://github.com/rohe/pyoidc@92389a1
 requests==2.9.1
 pymongo==3.2.2
+rq==0.5.6

--- a/src/se_leg_op/response_sender.py
+++ b/src/se_leg_op/response_sender.py
@@ -1,0 +1,21 @@
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def deliver_response_task(response_url):
+    # type: (str) -> None
+    """
+    Make a synchronous request to the specified url.
+    """
+    try:
+        resp = requests.get(response_url)
+    except requests.exceptions.RequestException as e:
+        logger.debug('could not deliver response to client', exc_info=True)
+        raise
+
+    if resp.status_code != 200:
+        logger.debug('client responded with unexpected http status \'%s\' on response to redirect_uri \'%s\'',
+                     resp.status_code, resp.request.url)

--- a/src/se_leg_op/service/run.py
+++ b/src/se_leg_op/service/run.py
@@ -1,7 +1,10 @@
+import logging
+
 from se_leg_op.service.app import oidc_provider_init_app
 
 name = 'oidc_provider'
 app = oidc_provider_init_app(name)
+logging.basicConfig(level=logging.DEBUG)
 
 if __name__ == '__main__':
     app.logger.info('Starting {} app...'.format(name))

--- a/tests/storage/redis.py
+++ b/tests/storage/redis.py
@@ -1,0 +1,65 @@
+import atexit
+import random
+import subprocess
+import time
+
+import redis
+
+
+class RedisTemporaryInstance(object):
+    """Singleton to manage a temporary Redis instance
+    Use this for testing purpose only. The instance is automatically destroyed
+    at the end of the program.
+    """
+    _instance = None
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+            atexit.register(cls._instance.shutdown)
+        return cls._instance
+
+    def __init__(self):
+        self._port = random.randint(40000, 50000)
+        self._process = subprocess.Popen(['redis-server',
+                                          '--port', str(self._port),
+                                          '--daemonize', 'no',
+                                          '--bind', '0.0.0.0',
+                                          '--databases', '1', ],
+                                         stdout=open('/tmp/redis-temp.log', 'wb'),
+                                         stderr=subprocess.STDOUT)
+
+        for i in range(10):
+            time.sleep(0.2)
+            try:
+                self._conn = redis.Redis('localhost', self._port, 0)
+                self._conn.set('dummy', 'dummy')
+            except redis.exceptions.ConnectionError:
+                continue
+            else:
+                break
+        else:
+            self.shutdown()
+            assert False, 'Cannot connect to the redis test instance'
+
+    @property
+    def conn(self):
+        return self._conn
+
+    @property
+    def port(self):
+        return self._port
+
+    def shutdown(self):
+        if self._process:
+            self._process.terminate()
+            self._process.wait()
+            self._process = None
+
+    def get_uri(self):
+        """
+        Convenience function to get a redis URI to the temporary database.
+        :return: redis://host:port/dbname
+        """
+        return 'redis://localhost:{}/0'.format(self.port)

--- a/tests/test_response_sender.py
+++ b/tests/test_response_sender.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+from urllib.parse import urlparse
+
+import pytest
+import responses
+import rq
+from oic.oic.message import AuthorizationResponse, AuthorizationRequest
+from redis.client import StrictRedis
+
+from se_leg_op.response_sender import deliver_response_task
+
+
+@pytest.fixture
+def message_queue():
+    return rq.Queue(async=False, connection=Mock(spec=StrictRedis))
+
+
+class TestDeliverResponse(object):
+    @responses.activate
+    def test_response_is_delivered(self, message_queue):
+        redirect_uri = 'https://client.example.com/redirect_uri'
+        responses.add(responses.GET, redirect_uri, status=200)
+        authentication_response = AuthorizationResponse(code='foobar')
+        message_queue.enqueue(deliver_response_task, authentication_response.request(redirect_uri))
+
+        assert len(responses.calls) == 1
+        parsed_url = urlparse(responses.calls[0].request.url)
+        assert parsed_url[:3] == urlparse(redirect_uri)[:3]
+        parsed_resp = AuthorizationResponse().from_urlencoded(parsed_url.query)
+        assert parsed_resp == authentication_response


### PR DESCRIPTION
To avoid doing long running http requests in the webservers main thread,
queue any authentication and error responses that should be delivered to
the clients' redirect_uri.