### PR TITLE
Store 'identity' attribute in the users db.

### DIFF
--- a/src/se_leg_op/service/views/vetting_process.py
+++ b/src/se_leg_op/service/views/vetting_process.py
@@ -24,7 +24,8 @@ def vetting_result():
 
     auth_req = AuthorizationRequest(**auth_req_data)
     # TODO store necessary user info
-    current_app.users[identity] = {'vetting_time': time.time()}
+    current_app.users[identity] = {'vetting_time': time.time(),
+                                   'identity': identity}
 
     authn_response = current_app.provider.authorize(AuthorizationRequest().from_dict(auth_req), identity,
                                                     extra_userinfo)

--- a/tests/service/test_app.py
+++ b/tests/service/test_app.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 import pytest
 import responses
-from oic.oic.message import AuthorizationResponse, AccessTokenResponse, OpenIDSchema
+from oic.oic.message import AuthorizationResponse, AccessTokenResponse, OpenIDSchema, ClaimsRequest, Claims
 from rq.worker import SimpleWorker
 
 from se_leg_op.service.app import SE_LEG_PROVIDER_SETTINGS_ENVVAR, MongoWrapper
@@ -55,7 +55,8 @@ class TestApp(object):
             'redirect_uri': TEST_REDIRECT_URI,
             'response_type': response_type,
             'response_mode': 'query',
-            'nonce': TEST_NONCE
+            'nonce': TEST_NONCE,
+            'claims': ClaimsRequest(userinfo=Claims(identity=None)).to_json()
         }
 
         resp = self.app.test_client().post('/authentication', data=request_args)
@@ -142,6 +143,7 @@ class TestApp(object):
         refresh_resp = self.make_refresh_request(token_resp['refresh_token'])
         userinfo = self.make_userinfo_request(refresh_resp['access_token'])
         assert token_resp['id_token']['sub'] == userinfo['sub']
+        assert userinfo['identity'] == TEST_USER_ID
 
     @responses.activate
     def test_hybrid_flow(self):
@@ -160,3 +162,4 @@ class TestApp(object):
         refresh_resp = self.make_refresh_request(token_resp['refresh_token'])
         userinfo = self.make_userinfo_request(refresh_resp['access_token'])
         assert token_resp['id_token']['sub'] == userinfo['sub']
+        assert userinfo['identity'] == TEST_USER_ID

--- a/tests/service/views/test_vetting_process.py
+++ b/tests/service/views/test_vetting_process.py
@@ -81,7 +81,7 @@ class TestVettingResultEndpoint(object):
         assert resp.status_code == 200
         # verify the original authentication request has been handled
         assert nonce not in self.app.authn_requests
-        assert TEST_USER_ID in self.app.provider.userinfo
+        assert self.app.users[TEST_USER_ID]['identity'] == TEST_USER_ID
 
         # force sending response from message queue from http://python-rq.org/docs/testing/
         worker = SimpleWorker([self.app.authn_response_queue], connection=self.app.authn_response_queue.connection)


### PR DESCRIPTION
Now clients can get the 'identity' attribute in the ID Token or Userinfo
Response simply by requesting it using the OIDC 'claims request
parameter'.

Storing the user identity as an attribute in the users db (instead of
using it only as the key) allows the existing mechanism for matching
requested claims in the authentication requests to find it