### PR TITLE
Bump flask and pyop version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pyop==2.0.0
-Flask==0.10.1
+pyop>=2.0.0,<2.1.0
+Flask>=0.12.2,<0.13
 requests==2.9.1
 certifi
 pymongo==3.2.2

--- a/src/se_leg_op/service/views/oidc_provider.py
+++ b/src/se_leg_op/service/views/oidc_provider.py
@@ -55,7 +55,7 @@ def authentication_endpoint():
 
 @oidc_provider_views.route('/.well-known/openid-configuration')
 def provider_configuration():
-    return jsonify(current_app.provider.provider_configuration)
+    return jsonify(current_app.provider.provider_configuration.to_dict())
 
 
 @oidc_provider_views.route('/jwks')


### PR DESCRIPTION
Call to_dict for provider_configuration as flask 0.12 has a pickier
jsonify