### PR TITLE
Handle vetting result POST as JSON

### DIFF
--- a/src/se_leg_op/plugins/nstic_vetting_process/license_service.py
+++ b/src/se_leg_op/plugins/nstic_vetting_process/license_service.py
@@ -76,7 +76,7 @@ def parse_vetting_data(data):
     :return: parsed data
     :rtype: dict
     """
-    parsed_data = {}
+    parsed_data = dict()
     # The soap service wants the mibi data in a json string
     parsed_data['mibi_data'] = json.dumps(data['mibi'])
     # The soap service wants to encode the image data so lets decode it here

--- a/src/se_leg_op/plugins/nstic_vetting_process/license_service.py
+++ b/src/se_leg_op/plugins/nstic_vetting_process/license_service.py
@@ -71,16 +71,15 @@ def init_mobile_verify_service_queue(config):
 
 def parse_vetting_data(data):
     """
-    :param data: JSON string
-    :type data: str
+    :param data: vetting data
+    :type data: dict
     :return: parsed data
     :rtype: dict
     """
     parsed_data = {}
-    vetting_data = json.loads(data)
     # The soap service wants the mibi data in a json string
-    parsed_data['mibi_data'] = json.dumps(vetting_data['mibi'])
+    parsed_data['mibi_data'] = json.dumps(data['mibi'])
     # The soap service wants to encode the image data so lets decode it here
-    parsed_data['front_image_data'] = base64.b64decode(vetting_data['encodedData'])
-    parsed_data['barcode_data'] = vetting_data['barcode']
+    parsed_data['front_image_data'] = base64.b64decode(data['encodedData'])
+    parsed_data['barcode_data'] = data['barcode']
     return parsed_data

--- a/src/se_leg_op/plugins/nstic_vetting_process/views/yubico_vetting.py
+++ b/src/se_leg_op/plugins/nstic_vetting_process/views/yubico_vetting.py
@@ -19,9 +19,10 @@ yubico_vetting_process_views = Blueprint('yubico_vetting_process', __name__, url
 @yubico_vetting_process_views.route('/vetting-result', methods=['POST'])
 def vetting_result():
     data = flask.request.get_json()
+    qrcode = data.get('qrcode')
 
     try:
-        qrdata = parse_qrdata(data['qrcode'])
+        qrdata = parse_qrdata(qrcode)
     except InvalidQrDataError as e:
         return make_response(str(e), 400)
 

--- a/src/se_leg_op/plugins/nstic_vetting_process/views/yubico_vetting.py
+++ b/src/se_leg_op/plugins/nstic_vetting_process/views/yubico_vetting.py
@@ -5,7 +5,6 @@ from flask.blueprints import Blueprint
 from flask.globals import current_app
 from flask.helpers import make_response
 from oic.oic.message import AuthorizationRequest
-from urllib import parse as urllib_parse
 from time import time
 
 from se_leg_op.service.vetting_process_tools import parse_qrdata, InvalidQrDataError
@@ -19,13 +18,10 @@ yubico_vetting_process_views = Blueprint('yubico_vetting_process', __name__, url
 
 @yubico_vetting_process_views.route('/vetting-result', methods=['POST'])
 def vetting_result():
-    data = flask.request.form['data']
-    # Unquote the data parameter again, it seems double encoded
-    data = urllib_parse.unquote(data)
-    qrcode = flask.request.form['qrcode']
+    data = flask.request.get_json()
 
     try:
-        qrdata = parse_qrdata(qrcode)
+        qrdata = parse_qrdata(data['qrcode'])
     except InvalidQrDataError as e:
         return make_response(str(e), 400)
 

--- a/src/se_leg_op/plugins/se_leg_vetting_process/views.py
+++ b/src/se_leg_op/plugins/se_leg_vetting_process/views.py
@@ -21,8 +21,9 @@ blueprints = [se_leg_vetting_process_views]
 
 @se_leg_vetting_process_views.route('/vetting-result', methods=['POST'])
 def vetting_result():
-    identity = flask.request.form['identity']
-    qrcode = flask.request.form['qrcode']
+    data = flask.request.get_json()
+    identity = data['identity']
+    qrcode = data['qrcode']
 
     try:
         qrdata = parse_qrdata(qrcode)

--- a/src/se_leg_op/plugins/se_leg_vetting_process/views.py
+++ b/src/se_leg_op/plugins/se_leg_vetting_process/views.py
@@ -22,8 +22,11 @@ blueprints = [se_leg_vetting_process_views]
 @se_leg_vetting_process_views.route('/vetting-result', methods=['POST'])
 def vetting_result():
     data = flask.request.get_json()
-    identity = data['identity']
-    qrcode = data['qrcode']
+    identity = data.get('identity')
+    qrcode = data.get('qrcode')
+
+    if not identity:
+        return make_response('Missing identity', 400)
 
     try:
         qrdata = parse_qrdata(qrcode)

--- a/tests/plugins/test_se_leg_vetting_process.py
+++ b/tests/plugins/test_se_leg_vetting_process.py
@@ -51,8 +51,8 @@ class TestVettingResultEndpoint(object):
 
         token = 'token'
         qrdata = '1' + json.dumps({'nonce': nonce, 'token': token})
-        resp = self.app.test_client().post('/vetting-result', data={'qrcode': qrdata,
-                                                                    'identity': TEST_USER_ID})
+        data = {'qrcode': qrdata, 'identity': TEST_USER_ID}
+        resp = self.app.test_client().post('/vetting-result', data=json.dumps(data), content_type='application/json')
 
         assert resp.status_code == 200
         # verify the original authentication request has been handled
@@ -75,7 +75,8 @@ class TestVettingResultEndpoint(object):
         {'qrcode': 'nonce token'},  # missing 'identity'
     ])
     def test_vetting_endpoint_with_missing_data(self, parameters):
-        resp = self.app.test_client().post('/vetting-result', data=parameters)
+        resp = self.app.test_client().post('/vetting-result', data=json.dumps(parameters),
+                                           content_type='application/json')
         assert resp.status_code == 400
 
     @pytest.mark.parametrize('qrdata', [
@@ -85,12 +86,12 @@ class TestVettingResultEndpoint(object):
         '1{"nonce": "nonce"}',  # missing 'token'
         '2{"token": "token", "nonce": "nonce"}'  # invalid qr version
     ])
-    def test_vetting_endpoint_with_invalid_qr_data(self, authn_request_args, qrdata):
-        resp = self.app.test_client().post('/vetting-result', data={'qrcode': qrdata,
-                                                                    'identity': TEST_USER_ID})
+    def test_vetting_endpoint_with_invalid_qr_data(self, qrdata):
+        data = {'qrcode': qrdata, 'identity': TEST_USER_ID}
+        resp = self.app.test_client().post('/vetting-result', data=json.dumps(data), content_type='application/json')
         assert resp.status_code == 400
 
     def test_unexpected_nonce(self):
-        resp = self.app.test_client().post('/vetting-result', data={'qrcode': 'unexpected token',
-                                                                    'identity': TEST_USER_ID})
+        data = {'qrcode': 'unexpected token', 'identity': TEST_USER_ID}
+        resp = self.app.test_client().post('/vetting-result', data=json.dumps(data), content_type='application/json')
         assert resp.status_code == 400

--- a/tests/service/test_app.py
+++ b/tests/service/test_app.py
@@ -38,7 +38,8 @@ class TestApp(object):
             'qrcode': '1' + json.dumps({'nonce': TEST_NONCE, 'token': TEST_TOKEN}),
             'identity': TEST_USER_ID
         }
-        resp = self.app.test_client().post('/vetting-result', data=vetting_result)
+        resp = self.app.test_client().post('/vetting-result', data=json.dumps(vetting_result),
+                                           content_type='application/json')
         assert resp.status_code == 200
 
         # force all authentication responses to be sent


### PR DESCRIPTION
Content-type x-www-form-urlencoded mixed with base64 does not always
play well together. Data is now sent to se-leg-op as application/json.